### PR TITLE
Remove Vercel configuration for URL rewrites from vercel.json

### DIFF
--- a/devbyte-frontend/vercel.json
+++ b/devbyte-frontend/vercel.json
@@ -1,3 +1,0 @@
-{
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
-}


### PR DESCRIPTION
File throwing error on deployment, safely deleted to retry other means.